### PR TITLE
Revert "binder: add missing binder_unlock()"

### DIFF
--- a/drivers/android/binder.c
+++ b/drivers/android/binder.c
@@ -4491,10 +4491,8 @@ static unsigned int binder_poll(struct file *filp,
 	bool wait_for_proc_work;
 
 	thread = binder_get_thread(proc);
-	if (!thread) {
-		binder_unlock(__func__);
+	if (!thread)
 		return POLLERR;
-	}
 
 	binder_inner_proc_lock(thread->proc);
 	thread->looper |= BINDER_LOOPER_STATE_POLL;


### PR DESCRIPTION
This reverts commit febf108e6c82d981ac6306978129dccb75db8b64.

Signed-off-by: msdx321 <msdx321@gmail.com>