### PR TITLE
dts: Makefile: build rev26 dtb only

### DIFF
--- a/arch/arm64/boot/dts/exynos/Makefile
+++ b/arch/arm64/boot/dts/exynos/Makefile
@@ -1,17 +1,7 @@
 # SPDX-License-Identifier: GPL-2.0
-dtb-$(CONFIG_CAMERA_STAR2) += exynos9810-star2lte_eur_open_16.dtb \
-	exynos9810-star2lte_eur_open_17.dtb \
-	exynos9810-star2lte_eur_open_18.dtb \
-	exynos9810-star2lte_eur_open_20.dtb \
-	exynos9810-star2lte_eur_open_23.dtb \
-	exynos9810-star2lte_eur_open_26.dtb
+dtb-$(CONFIG_CAMERA_STAR2) += exynos9810-star2lte_eur_open_26.dtb
 
-dtb-$(CONFIG_CAMERA_STAR) += exynos9810-starlte_eur_open_16.dtb \
-	exynos9810-starlte_eur_open_17.dtb \
-	exynos9810-starlte_eur_open_18.dtb \
-	exynos9810-starlte_eur_open_20.dtb \
-	exynos9810-starlte_eur_open_23.dtb \
-	exynos9810-starlte_eur_open_26.dtb
+dtb-$(CONFIG_CAMERA_STAR) += exynos9810-starlte_eur_open_26.dtb
 
 always            := $(dtb-y) $(dtbo-y)
 clean-files       := *.dtb*


### PR DESCRIPTION
Other dtbs are unused and only inflate the size of the kernel. Only build the required rev26 dtb for starlte and star2lte instead.